### PR TITLE
Flush dom before recalculating columns to use correct width

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,18 +5,17 @@
   "main": "vaadin-board.html",
   "license": "https://raw.githubusercontent.com/vaadin/vaadin-board/master/LICENSE.txt",
   "dependencies": {
-    "polymer": "v2.0.0-rc.1",
+    "polymer": "^v2.0.0-rc.1",
     "vaadin-license-checker": "vaadin/license-checker#2.0-preview"
   },
   "devDependencies": {
+    "app-layout": "PolymerElements/app-layout#2.0-preview",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "v1.0.0-rc.4",
+    "webcomponentsjs": "^v1.0.0-rc.4",
     "test-fixture": "^2.0.0"
   },
   "resolutions": {
-    "polymer":"v2.0.0-rc.1",
-    "webcomponentsjs": "v1.0.0-rc.4",
     "test-fixture": "^2.0.0",
-    "custom-elements": "master"
+    "polymer": "^v2.0.0-rc.1"
   }
 }

--- a/test/board-in-app-layout.html
+++ b/test/board-in-app-layout.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta id="viewport" name="viewport"
+          content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../vaadin-board-row.html">
+    <link rel="import" href="../../app-layout/app-drawer/app-drawer.html">
+    <link rel="import" href="../../app-layout/app-drawer-layout/app-drawer-layout.html">
+    <link rel="import" href="../../app-layout/app-header-layout/app-header-layout.html">
+
+  </head>
+  <body>
+    <!-- Simple app layout with a drawer menu and a vaadin-board content-->
+    <app-drawer-layout fullbleed>
+      <app-drawer id="drawer" slot="drawer">
+        <h1>Menu title</h1>
+      </app-drawer>
+      <app-header-layout has-scrolling-region>
+        <vaadin-board-row>
+          <div>top A</div>
+          <div>top B</div>
+          <div>top C</div>
+          <div>top D</div>
+        </vaadin-board-row>
+      </app-header-layout>
+    </app-drawer-layout>
+
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
     let suites =[
         'vaadin-board_boardcols_test.html',
         'vaadin-board_light_dom_test.html',
+        'vaadin-board_media-queries.html',
         'vaadin-board_redraw_test.html',
         'vaadin-board_style.html',
         'vaadin-board_test.html'

--- a/test/vaadin-board_boardcols_test.html
+++ b/test/vaadin-board_boardcols_test.html
@@ -102,7 +102,7 @@
           var rowRect = row.getBoundingClientRect();
 
           var children = row.querySelectorAll("div");
-          var expectedLeftOffset = [0, expected(1/2,rowRect.width), expected(3/4,rowRect.width)];
+          var expectedLeftOffset = [0, expected(1 / 2, rowRect.width), expected(3 / 4, rowRect.width)];
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
@@ -116,31 +116,30 @@
           var rowRect = row.getBoundingClientRect();
 
           var children = row.querySelectorAll("div");
-          var expectedLeftOffset = [0, expected(1/3,rowRect.width), expected(2/3,rowRect.width)];
-          var expectedToptOffset = [0, 0, 0];
+          var expectedLeftOffset = [0, expected(1 / 3, rowRect.width), expected(2 / 3, rowRect.width)];
+          var expectedTopOffset = [0, 0, 0];
 
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
             assert.approximately(rect.left, rowRect.left + expectedLeftOffset[i], 1, "Three items take 33% each.");
-            assert.approximately(rect.top, rowRect.top + expectedToptOffset[i], 1);
+            assert.approximately(rect.top, rowRect.top + expectedTopOffset[i], 1);
           }
         });
 
         test('Item with colspan 2 takes 100% on Tablet.', function () {
-
           var row = fixture('tablet-board-row');
           var rowRect = row.getBoundingClientRect();
 
           var children = row.querySelectorAll("div");
-          var expectedLeftOffset = [0, 0, expected(1/2,rowRect.width)];
-          var expectedToptOffset = [0, expected(1/2,rowRect.height),expected(1/2, rowRect.height)];
+          var expectedLeftOffset = [0, 0, expected(1 / 2, rowRect.width)];
+          var expectedTopOffset = [0, expected(1 / 2, rowRect.height), expected(1 / 2, rowRect.height)];
 
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
-            assert.approximately(rect.left, rowRect.left+expectedLeftOffset[i], 1, "Row and content left are equal");
-            assert.approximately(rect.top, rowRect.top + expectedToptOffset[i], 1);
+            assert.approximately(rect.left, rowRect.left + expectedLeftOffset[i], 1, "Row and content left are equal");
+            assert.approximately(rect.top, rowRect.top + expectedTopOffset[i], 1);
           }
         });
 
@@ -149,14 +148,14 @@
           var rowRect = row.getBoundingClientRect();
 
           var children = row.querySelectorAll("div");
-          var expectedLeftOffset = [0, expected(1/3,rowRect.width), expected(2/3,rowRect.width)];
-          var expectedToptOffset = [0, 0, 0];
+          var expectedLeftOffset = [0, expected(1 / 3, rowRect.width), expected(2 / 3, rowRect.width)];
+          var expectedTopOffset = [0, 0, 0];
 
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
             assert.approximately(rect.left, rowRect.left + expectedLeftOffset[i], 1, "Three items take 33% each on Tablet.");
-            assert.approximately(rect.top, rowRect.top + expectedToptOffset[i], 1);
+            assert.approximately(rect.top, rowRect.top + expectedTopOffset[i], 1);
           }
         });
 
@@ -184,29 +183,29 @@
         );
 
         test('Extra Item without board-cols dropped and there is a warning message', function () {
-            var row = fixture('desktop-board-row-extra');
-            var children = row.querySelectorAll("div");
-            assert.equal(children.length,4,"Number of children div should be 4");
-            assert.equal(warnMessage,"The column configuration is not valid; column count should add up to 3 or 4.");
-          })
+          var row = fixture('desktop-board-row-extra');
+          var children = row.querySelectorAll("div");
+          assert.equal(children.length, 4, "Number of children div should be 4");
+          assert.equal(warnMessage, "The column configuration is not valid; column count should add up to 3 or 4.");
+        })
 
         test('Extra Item with board-cols, that does not fit. Board-cols is dropped and there is a warning message.', function () {
           var row = fixture('desktop-board-row-extra-col2');
 
           var children = row.querySelectorAll("div");
-          assert.equal(children.length,4,"Number of children div should be 4");
-          assert.equal(warnMessage,"The column configuration is not valid; column count should add up to 3 or 4.");
+          assert.equal(children.length, 4, "Number of children div should be 4");
+          assert.equal(warnMessage, "The column configuration is not valid; column count should add up to 3 or 4.");
         });
 
-        teardown(function(){
+        teardown(function () {
           console.warn = oldWarn;
         })
 
         test('Board cols 2/3 and 1/3 should use 2/3 and 1/3 available space.', function () {
           var row = fixture('board-row-3-items-board-cols');
           var children = row.querySelectorAll("div");
-          var rowRect= row.getBoundingClientRect();
-          var expectedLeftOffset = [0, expected(2/3,rowRect.width)];
+          var rowRect = row.getBoundingClientRect();
+          var expectedLeftOffset = [0, expected(2 / 3, rowRect.width)];
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
             assert.approximately(rect.left, rowRect.left + expectedLeftOffset[i], 1);

--- a/test/vaadin-board_media-queries.html
+++ b/test/vaadin-board_media-queries.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>vaadin-board test</title>
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+  </head>
+  <body>
+    <test-fixture id="board-in-app-layout">
+      <template>
+        <iframe id="app-iframe" src="board-in-app-layout.html"></iframe>
+      </template>
+    </test-fixture>
+    <script>
+      suite('vaadin-board', function () {
+
+        test('Row has right layout after media query hides menu', function (done) {
+
+          var iframe = fixture('board-in-app-layout');
+          var row;
+          var finalSizeCheck = function () {
+            //if menu is hidden size then for row should be medium
+            assert.equal(row.className, 'medium');
+            done();
+          };
+          var initialSizeCheck = function () {
+            row = iframe.contentDocument.querySelector('vaadin-board-row');
+            //if menu is visible then size for row should be small
+            assert.equal(row.className, 'small');
+            //a size less than or equal to 640 will hide menu
+            iframe.width = 640;
+            setTimeout(finalSizeCheck, 100);
+          };
+          var setInitialSize = function () {
+            //a size bigger than 640 will show menu
+            iframe.width = 641;
+            setTimeout(initialSizeCheck, 100);
+          };
+
+          iframe.contentWindow.addEventListener('WebComponentsReady', setInitialSize);
+        });
+
+      });
+    </script>
+  </body>
+</html>

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -54,9 +54,9 @@
     <script>
       suite('vaadin-board', function () {
 
-        test('Changing styling of the board and calling redraw triggers relayouting', function() {
+        test('Changing styling of the board and calling redraw triggers relayouting', function () {
           var board = fixture('board-1-row-4-items');
-          board.style.width="700px";
+          board.style.width = "700px";
           board.redraw();
 
           var row = board.querySelector('#top');
@@ -65,14 +65,14 @@
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
-            assert.approximately(rect.left, (i%2 * rowRect.width / 2)+rowRect.left, 1);
-            assert.approximately(rect.top, (Math.floor(i/2) * rowRect.height / 2)+rowRect.top,1);
+            assert.approximately(rect.left, (i % 2 * rowRect.width / 2) + rowRect.left, 1);
+            assert.approximately(rect.top, (Math.floor(i / 2) * rowRect.height / 2) + rowRect.top, 1);
           }
         });
 
-        test('Changing styling of the board and calling redraw triggers relayouting for nested rows', function() {
+        test('Changing styling of the board and calling redraw triggers relayouting for nested rows', function () {
           var board = fixture('board-1-row-4-items-nested');
-          board.style.width="900px";
+          board.style.width = "900px";
           board.redraw();
 
           var nestedRow = board.querySelector('#nested');
@@ -83,7 +83,7 @@
             var rect = children[i].getBoundingClientRect();
 
             assert.approximately(rect.left, nestedRowRect.left, 1);
-            assert.approximately(rect.top, nestedRowRect.top+rect.height*i ,1);
+            assert.approximately(rect.top, nestedRowRect.top + rect.height * i, 1);
           }
         });
 
@@ -91,7 +91,8 @@
           var board = fixture('board-1-row-4-items-nested');
           var nestedRow = board.querySelector('#nested');
           var nestedRowRect = nestedRow.getBoundingClientRect();
-          var expectedLeftOffset = [0, expected(1 / 2, nestedRowRect.width),0, expected(1 / 2, nestedRowRect.width)];
+          var expectedLeftOffset = [0, expected(1 / 2, nestedRowRect.width), 0, expected(1 / 2, nestedRowRect.width)];
+
           board.style.width = "900px";
           board.redraw();
           board.style.width = "1200px";
@@ -107,9 +108,9 @@
           }
         });
 
-        test('Changing styling of the row and calling redraw triggers relayouting', function() {
+        test('Changing styling of the row and calling redraw triggers relayouting', function () {
           var row = fixture('board-row-4-items');
-          row.style.width="700px";
+          row.style.width = "700px";
           row.redraw();
 
           var rowRect = row.getBoundingClientRect();
@@ -117,8 +118,8 @@
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
-            assert.approximately(rect.left, (i%2 * rowRect.width / 2)+rowRect.left, 1);
-            assert.approximately(rect.top, (Math.floor(i/2) * rowRect.height / 2)+rowRect.top,1);
+            assert.approximately(rect.left, (i % 2 * rowRect.width / 2) + rowRect.left, 1);
+            assert.approximately(rect.top, (Math.floor(i / 2) * rowRect.height / 2) + rowRect.top, 1);
           }
         });
       });

--- a/test/vaadin-board_style.html
+++ b/test/vaadin-board_style.html
@@ -56,9 +56,9 @@
         test('Items inside the board-row has different styling, based on row size.', function () {
           var board = fixture('board');
           var rows = board.querySelectorAll("vaadin-board-row");
-          assert.equal("rgb(255, 0, 0)",window.getComputedStyle(rows[0].querySelector("div")).backgroundColor);
-          assert.equal("rgb(0, 255, 0)",window.getComputedStyle(rows[1].querySelector("div")).backgroundColor);
-          assert.equal("rgb(0, 0, 255)",window.getComputedStyle(rows[2].querySelector("div")).backgroundColor);
+          assert.equal("rgb(255, 0, 0)", window.getComputedStyle(rows[0].querySelector("div")).backgroundColor);
+          assert.equal("rgb(0, 255, 0)", window.getComputedStyle(rows[1].querySelector("div")).backgroundColor);
+          assert.equal("rgb(0, 0, 255)", window.getComputedStyle(rows[2].querySelector("div")).backgroundColor);
         });
       });
     </script>

--- a/test/vaadin-board_test.html
+++ b/test/vaadin-board_test.html
@@ -16,12 +16,12 @@
   <body>
     <test-fixture id="desktop-board-row">
       <template>
-          <vaadin-board-row style="width:1200px">
-            <div>top A</div>
-            <div>top B</div>
-            <div>top C</div>
-            <div>top D</div>
-          </vaadin-board-row>
+        <vaadin-board-row style="width:1200px">
+          <div>top A</div>
+          <div>top B</div>
+          <div>top C</div>
+          <div>top D</div>
+        </vaadin-board-row>
       </template>
     </test-fixture>
     <test-fixture id="tablet-board-row">
@@ -73,8 +73,8 @@
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
-            assert.approximately(rowRect.top, rect.top,1, "Row and content top are equal");
-            assert.approximately(rect.left, (i * rowRect.width / 4)+rowRect.left, 1);
+            assert.approximately(rowRect.top, rect.top, 1, "Row and content top are equal");
+            assert.approximately(rect.left, (i * rowRect.width / 4) + rowRect.left, 1);
           }
         });
 
@@ -86,8 +86,8 @@
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
-            assert.approximately(rect.left, (i%2 * rowRect.width / 2)+rowRect.left, 1);
-            assert.approximately(rect.top, (Math.floor(i/2) * rowRect.height / 2)+rowRect.top, 1);
+            assert.approximately(rect.left, (i % 2 * rowRect.width / 2) + rowRect.left, 1);
+            assert.approximately(rect.top, (Math.floor(i / 2) * rowRect.height / 2) + rowRect.top, 1);
           }
         });
 
@@ -100,7 +100,7 @@
             var rect = children[i].getBoundingClientRect();
 
             assert.approximately(rect.left, rowRect.left, 1);
-            assert.approximately(rect.top, (i * rowRect.height / 4)+rowRect.top, 1);
+            assert.approximately(rect.top, (i * rowRect.height / 4) + rowRect.top, 1);
           }
         });
 
@@ -113,7 +113,7 @@
             var rect = children[i].getBoundingClientRect();
 
             assert.equal(rowRect.top, rect.top, "Row and content top are equal");
-            assert.approximately(rect.left, (i * rowRect.width / 2)+rowRect.left, 1);
+            assert.approximately(rect.left, (i * rowRect.width / 2) + rowRect.left, 1);
           }
         });
 
@@ -125,8 +125,8 @@
           for (let i = 0; i < children.length; i++) {
             var rect = children[i].getBoundingClientRect();
 
-            assert.approximately(rect.left, (i%2 * rowRect.width / 2)+rowRect.left, 1);
-            assert.approximately(rect.top, (Math.floor(i/2) * rowRect.height / 2)+rowRect.top,1);
+            assert.approximately(rect.left, (i % 2 * rowRect.width / 2) + rowRect.left, 1);
+            assert.approximately(rect.top, (Math.floor(i / 2) * rowRect.height / 2) + rowRect.top, 1);
           }
         });
 

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -163,6 +163,7 @@
       }
 
       _onIronResize() {
+        Polymer.dom.flush();
         this._recalculateFlexBasis(false);
       }
 


### PR DESCRIPTION
Fixes issue when using board and media queries #27

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/30)
<!-- Reviewable:end -->
