### PR TITLE
Set vaadin-board-row content width, not flexbasis

### DIFF
--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -180,7 +180,11 @@
               let newFlexBasis = this._calculateFlexBasis(boardCols[i], width, colsInRow);
               if(forceResize || !this._oldFlexBasis[i] || this._oldFlexBasis[i] != newFlexBasis) {
                   this._oldFlexBasis[i] = newFlexBasis
-                  e.style.flexBasis = newFlexBasis;
+                // e.style.flexBasis = newFlexBasis;
+                // This fixes issue with vaadin-charts resizing.
+                // https://github.com/highcharts/highcharts/issues/6427
+                // May cause some isses, keep this until we found a better solution.
+                  e.style.width = newFlexBasis;
               }
           });
           this._oldWidth = width;


### PR DESCRIPTION
This fixes problem with charts resize.
https://github.com/highcharts/highcharts/issues/6427

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/31)
<!-- Reviewable:end -->
