### PR TITLE
Add iron-resizable-behavior dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   "license": "https://raw.githubusercontent.com/vaadin/vaadin-board/master/LICENSE.txt",
   "dependencies": {
     "polymer": "^v2.0.0-rc.1",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#2.0-preview",
     "vaadin-license-checker": "vaadin/license-checker#2.0-preview"
   },
   "devDependencies": {


### PR DESCRIPTION
It used to work in the component project because iron-resizable-behavior is a transitive dependency of a devdependency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/40)
<!-- Reviewable:end -->
