### PR TITLE
Add missing iron-component-page dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "app-layout": "PolymerElements/app-layout#2.0-preview",
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "^1.0.0-rc.4",
     "test-fixture": "^2.0.0"


### PR DESCRIPTION
It's required here: https://github.com/vaadin/vaadin-board/blob/master/index.html#L11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/49)
<!-- Reviewable:end -->
