### PR TITLE
Reimplement vaadin-board-row with CSS Grid

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -22,6 +22,21 @@
           <div class="top d">top D</div>
         </vaadin-board-row>
         <vaadin-board-row>
+          <div class="top a" board-cols="2">startspan A</div>
+          <div class="top b">startspan B</div>
+          <div class="top c">startspan C</div>
+        </vaadin-board-row>
+        <vaadin-board-row>
+          <div class="top a">midspan A</div>
+          <div class="top b" board-cols="2">midspan B</div>
+          <div class="top c">midspan C</div>
+        </vaadin-board-row>
+        <vaadin-board-row>
+          <div class="top a">endspan A</div>
+          <div class="top b">endspan B</div>
+          <div class="top c" board-cols="2">endspan C</div>
+        </vaadin-board-row>
+        <vaadin-board-row>
           <div class="mid">mid</div>
         </vaadin-board-row>
         <vaadin-board-row>

--- a/test/vaadin-board_slot_test.html
+++ b/test/vaadin-board_slot_test.html
@@ -49,24 +49,6 @@
     <script>
       suite('vaadin-board-with-slotted-element', function (done) {
 
-        test('Inner items have 25% flex css.', function () {
-
-          // Test was failing in Chrome because of this bug in Shadydom:
-          // https://github.com/webcomponents/shadydom/issues/168
-          // TODO Remove when the issue is fixed.
-          if (!Polymer.Settings.useShadow) {
-            return;
-          }
-          var boardElement = fixture('slot-board-row');
-          var children = boardElement.querySelectorAll("div");
-          for (let i = 0; i < children.length; i++) {
-            var child = children[i];
-
-            assert.isAtLeast(child.getAttribute("style").indexOf("flex-basis: 25%"), 0,
-                    "Row children have flex-basis: 25% style");
-          }
-        });
-
         test('Slot tag inside board child elements, does not effect number of board children.', function () {
 
           // Test was failing in Chrome because of this bug in Shadydom:

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -6,23 +6,29 @@
     <style>
        :host {
         display: grid;
+        display: -ms-grid;
         grid-template-columns: 1fr 1fr 1fr 1fr;
+        -ms-grid-columns: 1fr 1fr 1fr 1fr;
       }
 
       :host(.one-column) {
         grid-template-columns: 1fr;
+        -ms-grid-columns: 1fr;
       }
 
       :host(.two-columns) {
         grid-template-columns: 1fr 1fr;
+        -ms-grid-columns: 1fr 1fr;
       }
 
       :host(.three-columns) {
         grid-template-columns: 1fr 1fr 1fr;
+        -ms-grid-columns: 1fr 1fr 1fr;
       }
 
       :host(.four-columns) {
         grid-template-columns: 1fr 1fr 1fr 1fr;
+        -ms-grid-columns: 1fr 1fr 1fr 1fr;
       }
 
        :host ::slotted(*) {
@@ -200,8 +206,8 @@
               
               var itemSize = boardCols[i];
               let nextItemSize = boardCols[i+1];
-              var placesLeft = colsInRow - (spaceUsedSoFar % colsInRow);
-
+              let placesLeft = colsInRow - (spaceUsedSoFar % colsInRow);
+              
               // an item can't take more columns than columns in a row
               if(itemSize > colsInRow){
                 itemSize = colsInRow;
@@ -222,21 +228,37 @@
               if (nextItemSize == null && itemSize < placesLeft){
                 itemSize = placesLeft
               }
-
+              
               if (itemSize > 1) {
                 e.style.gridColumnEnd = "span " + itemSize;
               } else {
                 e.style.gridColumnEnd = "";
               }
+
+              // IE10, IE11 and Edge has an old, older implementation of the CSS Grid spec.
+              // That spec does not include auto placement, so each item needs to have 
+              // column and row defined. Remove this when Edge has implemented current
+              // support and we do not support IE10 / IE 11 anymore.
+              e.style.msGridColumn = (spaceUsedSoFar % colsInRow)+1;
+              e.style.msGridRow = Math.floor(spaceUsedSoFar / colsInRow)+1;;
+              if (itemSize > 1) {
+                e.style.msGridColumnSpan = itemSize;
+              } else {
+                e.style.msGridColumnSpan = "";
+              }
+              
+              //save for next iteration
               spaceUsedSoFar = spaceUsedSoFar + itemSize;
-            });
+            });    
             this._oldWidth = width;
           }
         }
 
-
         _setColumns(columns) {
-          this.classList.remove("one-column","two-columns","three-columns","four-columns");
+          this.classList.remove("one-column");
+          this.classList.remove("two-columns");
+          this.classList.remove("three-columns");
+          this.classList.remove("four-columns");
           switch (columns) {
             case 1: this.classList.add("one-column"); break;
             case 2: this.classList.add("two-columns"); break;

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -229,7 +229,7 @@
                 itemSize = placesLeft
               }
               
-              if (itemSize > 1) {
+              if (itemSize > 1) {
                 e.style.gridColumnEnd = "span " + itemSize;
               } else {
                 e.style.gridColumnEnd = "";
@@ -240,8 +240,8 @@
               // column and row defined. Remove this when Edge has implemented current
               // support and we do not support IE10 / IE 11 anymore.
               e.style.msGridColumn = (spaceUsedSoFar % colsInRow)+1;
-              e.style.msGridRow = Math.floor(spaceUsedSoFar / colsInRow)+1;;
-              if (itemSize > 1) {
+              e.style.msGridRow = Math.floor(spaceUsedSoFar / colsInRow)+1;
+              if (itemSize > 1) {
                 e.style.msGridColumnSpan = itemSize;
               } else {
                 e.style.msGridColumnSpan = "";

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -5,15 +5,28 @@
   <template>
     <style>
        :host {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        align-items: stretch;
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+      }
+
+      :host(.one-column) {
+        grid-template-columns: 1fr;
+      }
+
+      :host(.two-columns) {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      :host(.three-columns) {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+
+      :host(.four-columns) {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
       }
 
        :host ::slotted(*) {
         box-sizing: border-box;
-        flex-grow: 1;
         overflow: hidden;
       }
     </style>
@@ -87,22 +100,6 @@
             this.classList.add(this._LARGE_VIEWPORT_CLASSNAME);
           }
         }
-        /**
-         * Calculates flex basis based on colSpan and width
-         * @param{Number} colspan value of the row
-         * @param{Number} width of the row in px
-         * @param{Number} amount of columns in the row
-         */
-        _calculateFlexBasis(colSpan, width, colsInRow) {
-          if (width < this._ONE_COLUMN_MAX_WIDTH) {
-            colsInRow = 1;
-          } else if (width < this._TWO_COLUMNS_MAX_WIDTH && colsInRow == 4) {
-            colsInRow = 2;
-          }
-          let flexBasis = colSpan / colsInRow * 100;
-          flexBasis = flexBasis > 100 ? 100 : flexBasis;
-          return flexBasis + '%';
-        }
 
         _reportError() {
           const errorMessage = "The column configuration is not valid; column count should add up to 3 or 4.";
@@ -171,14 +168,14 @@
         }
 
         redraw() {
-          this._recalculateFlexBasis(true);
+          this._recalculateItemSizes(true);
         }
 
         _onIronResize() {
-          this._recalculateFlexBasis(false);
+          this._recalculateItemSizes(false);
         }
 
-        _recalculateFlexBasis(forceResize) {
+        _recalculateItemSizes(forceResize) {
           const width = this.getBoundingClientRect().width;
           if (forceResize || width != this._oldWidth) {
             const nodes = this.$.insertionPoint.assignedNodes({ flatten: true });
@@ -187,18 +184,65 @@
                 || (node instanceof Polymer.DomRepeat)
                 || (node instanceof Polymer.DomIf));
             }
-            const filteredNodes = nodes.filter(isElementNode);
             this._addStyleNames(width);
+
+            const filteredNodes = nodes.filter(isElementNode);
             const boardCols = this._parseBoardCols(filteredNodes);
-            const colsInRow = boardCols.reduce((a, b) => a + b, 0);
-            this._removeExtraNodesFromDOM(boardCols, filteredNodes).forEach((e, i) => {
-              let newFlexBasis = this._calculateFlexBasis(boardCols[i], width, colsInRow);
-              if (forceResize || !this._oldFlexBasis[i] || this._oldFlexBasis[i] != newFlexBasis) {
-                this._oldFlexBasis[i] = newFlexBasis
-                e.style.flexBasis = newFlexBasis;
+            var colsInRow = boardCols.reduce((a, b) => a + b, 0);
+            if (width < this._ONE_COLUMN_MAX_WIDTH) {
+                colsInRow = 1;
+              } else if (width < this._TWO_COLUMNS_MAX_WIDTH && colsInRow == 4) {
+                colsInRow = 2;
               }
+            this._setColumns(colsInRow);
+            var spaceUsedSoFar = 0;
+            this._removeExtraNodesFromDOM(boardCols, filteredNodes).forEach((e, i) => {
+              
+              var itemSize = boardCols[i];
+              let nextItemSize = boardCols[i+1];
+              var placesLeft = colsInRow - (spaceUsedSoFar % colsInRow);
+
+              // an item can't take more columns than columns in a row
+              if(itemSize > colsInRow){
+                itemSize = colsInRow;
+              }
+              
+              // If there is space on current row, but next item won't fit in, then expand the 
+              // current item to take the rest of the space available in current row.
+              // Ie. 1-2-1 spans in two column size. second item won't fit to first row so expand
+              // first item to take the full row.
+              if (nextItemSize != null && itemSize < placesLeft && itemSize+nextItemSize > placesLeft) {
+                itemSize = placesLeft;
+              }
+              // If current item is the last in the row, and there is an empty space, expand
+              // it to take the whole row.
+              // Ie. 1-2-1 span. Last item is empty on the last row as second row needs an own
+              // row. Therefore last item should not only take first column of whole row, but
+              // expand to full row.
+              if (nextItemSize == null && itemSize < placesLeft){
+                itemSize = placesLeft
+              }
+
+              if (itemSize > 1) {
+                e.style.gridColumnEnd = "span " + itemSize;
+              } else {
+                e.style.gridColumnEnd = "";
+              }
+              spaceUsedSoFar = spaceUsedSoFar + itemSize;
             });
             this._oldWidth = width;
+          }
+        }
+
+
+        _setColumns(columns) {
+          this.classList.remove("one-column","two-columns","three-columns","four-columns");
+          switch (columns) {
+            case 1: this.classList.add("one-column"); break;
+            case 2: this.classList.add("two-columns"); break;
+            case 3: this.classList.add("three-columns"); break;
+            case 4:
+            default: this.classList.add("four-columns"); break;
           }
         }
       }


### PR DESCRIPTION
Reimplemented `vaadin-board-row` with CSS Grid instead of Flex layout. It gives easier support for adding gutters and the layout probably won't break by adding paddings and whatnot to items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/72)
<!-- Reviewable:end -->
