### PR TITLE
Make row sizes configurable with properties.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,8 @@
         'vaadin-board_style.html',
         'vaadin-board_test.html',
         'vaadin-board_slot_test.html',
-        'vaadin-board-template_test.html'
+        'vaadin-board-template_test.html',
+        'vaadin-board_size_test.html'
     ];
 
     /**

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -59,15 +59,6 @@
         var row_default;
         var row_smaller;
         var row_larger;
-        
-        beforeEach(function() {
-          container = fixture('board');
-          board = container.querySelectorAll("vaadin-board");
-          var rows = container.querySelectorAll("vaadin-board-row");
-          row_default = rows[0].querySelector("div");
-          row_smaller = rows[1].querySelector("div");
-          row_larger = rows[2].querySelector("div");
-        });
 
         function testSize(defaultColor, smallerColor, largerColor){
           assert.equal(defaultColor, window.getComputedStyle(row_default).backgroundColor);
@@ -76,6 +67,13 @@
         }
 
         test('Items inside the board-row has different styling, based on row size.', function () {
+          container = fixture('board');
+          board = container.querySelectorAll("vaadin-board");
+          var rows = container.querySelectorAll("vaadin-board-row");
+          row_default = rows[0].querySelector("div");
+          row_smaller = rows[1].querySelector("div");
+          row_larger = rows[2].querySelector("div");
+
           var large = "rgb(255, 0, 0)";
           var medium = "rgb(0, 255, 0)";
           var small = "rgb(0, 0, 255)";

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -54,12 +54,20 @@
     </test-fixture>
     <script>
       suite('vaadin-board', function () {
-        var container = fixture('board');
-        var board = container.querySelectorAll("vaadin-board");
-        var rows = container.querySelectorAll("vaadin-board-row");
-        var row_default = rows[0].querySelector("div");
-        var row_smaller = rows[1].querySelector("div");
-        var row_larger = rows[2].querySelector("div");
+        var container;
+        var board;
+        var row_default;
+        var row_smaller;
+        var row_larger;
+        
+        beforeEach(function() {
+          container = fixture('board');
+          board = container.querySelectorAll("vaadin-board");
+          var rows = container.querySelectorAll("vaadin-board-row");
+          row_default = rows[0].querySelector("div");
+          row_smaller = rows[1].querySelector("div");
+          row_larger = rows[2].querySelector("div");
+        });
 
         function testSize(defaultColor, smallerColor, largerColor){
           assert.equal(defaultColor, window.getComputedStyle(row_default).backgroundColor);

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>vaadin-board test</title>
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../vaadin-board.html">
+    <link rel="import" href="../vaadin-board-row.html">
+  </head>
+  <body>
+    <test-fixture id="board">
+      <style>
+
+        vaadin-board-row.large > div {
+          background-color: rgb(255, 0, 0);
+        }
+
+        vaadin-board-row.medium > div {
+          background-color: rgb(0, 255, 0);
+        }
+
+        vaadin-board-row.small > div {
+          background-color: rgb(0, 0, 255);
+        }
+      </style>
+      <template>
+        <div id="board">
+          <vaadin-board>
+            <vaadin-board-row id="default">
+              <div>top A</div>
+              <div>top B</div>
+            </vaadin-board-row>
+            <vaadin-board-row id="smaller" small-size="300" medium-size="700">
+              <div>top A</div>
+              <div>top B</div>
+              <div>top C</div>
+              <div>top D</div>
+            </vaadin-board-row>
+            <vaadin-board-row id="larger" small-size="800" medium-size="1300">
+              <div>top A</div>
+              <div>top B</div>
+              <div>top C</div>
+              <div>top D</div>
+            </vaadin-board-row>
+          </vaadin-board>
+        </div>
+      </template>
+    </test-fixture>
+    <script>
+      suite('vaadin-board', function () {
+        var container = fixture('board');
+        var board = container.querySelectorAll("vaadin-board");
+        var rows = container.querySelectorAll("vaadin-board-row");
+        var row_default = rows[0].querySelector("div");
+        var row_smaller = rows[1].querySelector("div");
+        var row_larger = rows[2].querySelector("div");
+
+        function testSize(defaultColor, smallerColor, largerColor){
+          assert.equal(defaultColor, window.getComputedStyle(row_default).backgroundColor);
+          assert.equal(smallerColor, window.getComputedStyle(row_smaller).backgroundColor);
+          assert.equal(largerColor, window.getComputedStyle(row_larger).backgroundColor);
+        }
+
+        test('Items inside the board-row has different styling, based on row size.', function () {
+          var large = "rgb(255, 0, 0)";
+          var medium = "rgb(0, 255, 0)";
+          var small = "rgb(0, 0, 255)";
+          
+          //Default 960 large test
+          container.setAttribute("style","width:980px");
+          board[0].redraw();
+          testSize(large, large, medium);
+          
+          container.setAttribute("style","width:940px");
+          board[0].redraw();
+          testSize(medium, large, medium);
+
+          //Default 600 medium test
+          container.setAttribute("style","width:620px");
+          board[0].redraw();
+          testSize(medium, medium, small);
+
+          container.setAttribute("style","width:580px");
+          board[0].redraw();
+          testSize(small, medium, small);
+
+          // 700 large test
+          container.setAttribute("style","width:720px");
+          board[0].redraw();
+          testSize(medium, large, small);
+
+          container.setAttribute("style","width:680px");
+          board[0].redraw();
+          testSize(medium, medium, small);
+          
+          // 300 medium test
+          container.setAttribute("style","width:320px");
+          board[0].redraw();
+          testSize(small, medium, small);
+
+          container.setAttribute("style","width:280px");
+          board[0].redraw();
+          testSize(small, small, small);
+
+          // 1300 large test
+          container.setAttribute("style","width:1320px");
+          board[0].redraw();
+          testSize(large, large, large);
+
+          container.setAttribute("style","width:1280px");
+          board[0].redraw();
+          testSize(large, large, medium);
+
+          // 800 medium test
+          container.setAttribute("style","width:820px");
+          board[0].redraw();
+          testSize(medium, large, medium);
+
+          container.setAttribute("style","width:780px");
+          board[0].redraw();
+          testSize(medium, large, small);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -37,11 +37,22 @@
         static get is() {
           return "vaadin-board-row";
         }
+
+        static get properties() {
+          return {
+            smallSize: {
+              type: Number,
+              value: 600
+            },
+            mediumSize: {
+              type: Number,
+              value: 960
+            }
+          }
+        }
         constructor() {
           super();
           this._onIronResize = this._onIronResize.bind(this);
-          this._ONE_COLUMN_MAX_WIDTH = 600;
-          this._TWO_COLUMNS_MAX_WIDTH = 960;
 
           this._SMALL_VIEWPORT_CLASSNAME = "small";
           this._MEDIUM_VIEWPORT_CLASSNAME = "medium";
@@ -74,11 +85,11 @@
          * Adds styles for board row based on width
          */
         _addStyleNames(width) {
-          if (width < this._ONE_COLUMN_MAX_WIDTH) {
+          if (width < this.smallSize) {
             this.classList.add(this._SMALL_VIEWPORT_CLASSNAME);
             this.classList.remove(this._MEDIUM_VIEWPORT_CLASSNAME);
             this.classList.remove(this._LARGE_VIEWPORT_CLASSNAME);
-          } else if (width < this._TWO_COLUMNS_MAX_WIDTH) {
+          } else if (width < this.mediumSize) {
             this.classList.remove(this._SMALL_VIEWPORT_CLASSNAME);
             this.classList.add(this._MEDIUM_VIEWPORT_CLASSNAME);
             this.classList.remove(this._LARGE_VIEWPORT_CLASSNAME);
@@ -95,9 +106,9 @@
          * @param{Number} amount of columns in the row
          */
         _calculateFlexBasis(colSpan, width, colsInRow) {
-          if (width < this._ONE_COLUMN_MAX_WIDTH) {
+          if (width < this.smallSize) {
             colsInRow = 1;
-          } else if (width < this._TWO_COLUMNS_MAX_WIDTH && colsInRow == 4) {
+          } else if (width < this.mediumSize && colsInRow == 4) {
             colsInRow = 2;
           }
           let flexBasis = colSpan / colsInRow * 100;

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -38,7 +38,7 @@
           return "vaadin-board-row";
         }
 
-        static get properties() {
+        static get properties() {
           return {
             smallSize: {
               type: Number,


### PR DESCRIPTION
Up until now, board-rows were always in large mode when over 960px, in medium when between 600px and 960px and small when under 600px. Now these are the defaults but they are configurable with properties small-size and medium-size. Example: <vaadin-board-row small-size=220 medium-size="620">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/84)
<!-- Reviewable:end -->
