### PR TITLE
Make row sizes configurable with properties.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,8 @@
         'vaadin-board_style.html',
         'vaadin-board_test.html',
         'vaadin-board_slot_test.html',
-        'vaadin-board-template_test.html'
+        'vaadin-board-template_test.html',
+        'vaadin-board_size_test.html'
     ];
 
     /**

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -16,6 +16,20 @@
   <body>
     <test-fixture id="board">
       <style>
+        vaadin-board-row {
+          --vaadin-board-width-small: 500px;
+          --vaadin-board-width-medium: 900px;
+        }
+
+        vaadin-board-row#smaller {
+          --vaadin-board-width-small: 300px;
+          --vaadin-board-width-medium: 700px;
+        }
+
+        vaadin-board-row#larger {
+          --vaadin-board-width-small: 800px;
+          --vaadin-board-width-medium: 1300px;
+        }
 
         vaadin-board-row.large > div {
           background-color: rgb(255, 0, 0);
@@ -33,20 +47,22 @@
         <div id="board">
           <vaadin-board>
             <vaadin-board-row id="default">
-              <div>top A</div>
-              <div>top B</div>
+              <div>default A</div>
+              <div>default B</div>
+              <div>default C</div>
+              <div>default D</div>
             </vaadin-board-row>
-            <vaadin-board-row id="smaller" small-size="300" medium-size="700">
-              <div>top A</div>
-              <div>top B</div>
-              <div>top C</div>
-              <div>top D</div>
+            <vaadin-board-row id="smaller">
+              <div>smaller A</div>
+              <div>smaller B</div>
+              <div>smaller C</div>
+              <div>smaller D</div>
             </vaadin-board-row>
-            <vaadin-board-row id="larger" small-size="800" medium-size="1300">
-              <div>top A</div>
-              <div>top B</div>
-              <div>top C</div>
-              <div>top D</div>
+            <vaadin-board-row id="larger">
+              <div>larger A</div>
+              <div>larger B</div>
+              <div>larger C</div>
+              <div>larger D</div>
             </vaadin-board-row>
           </vaadin-board>
         </div>
@@ -78,21 +94,21 @@
           var medium = "rgb(0, 255, 0)";
           var small = "rgb(0, 0, 255)";
           
-          //Default 960 large test
-          container.setAttribute("style","width:980px");
+          //Default 900 large test
+          container.setAttribute("style","width:920px");
           board[0].redraw();
           testSize(large, large, medium);
           
-          container.setAttribute("style","width:940px");
+          container.setAttribute("style","width:880px");
           board[0].redraw();
           testSize(medium, large, medium);
 
-          //Default 600 medium test
-          container.setAttribute("style","width:620px");
+          //Default 500 medium test
+          container.setAttribute("style","width:520px");
           board[0].redraw();
           testSize(medium, medium, small);
 
-          container.setAttribute("style","width:580px");
+          container.setAttribute("style","width:480px");
           board[0].redraw();
           testSize(small, medium, small);
 

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -59,15 +59,6 @@
         var row_default;
         var row_smaller;
         var row_larger;
-        
-        beforeEach(function() {
-          container = fixture('board');
-          board = container.querySelectorAll("vaadin-board");
-          var rows = container.querySelectorAll("vaadin-board-row");
-          row_default = rows[0].querySelector("div");
-          row_smaller = rows[1].querySelector("div");
-          row_larger = rows[2].querySelector("div");
-        });
 
         function testSize(defaultColor, smallerColor, largerColor){
           assert.equal(defaultColor, window.getComputedStyle(row_default).backgroundColor);
@@ -76,6 +67,13 @@
         }
 
         test('Items inside the board-row has different styling, based on row size.', function () {
+          container = fixture('board');
+          board = container.querySelectorAll("vaadin-board");
+          var rows = container.querySelectorAll("vaadin-board-row");
+          row_default = rows[0].querySelector("div");
+          row_smaller = rows[1].querySelector("div");
+          row_larger = rows[2].querySelector("div");
+
           var large = "rgb(255, 0, 0)";
           var medium = "rgb(0, 255, 0)";
           var small = "rgb(0, 0, 255)";

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -54,12 +54,20 @@
     </test-fixture>
     <script>
       suite('vaadin-board', function () {
-        var container = fixture('board');
-        var board = container.querySelectorAll("vaadin-board");
-        var rows = container.querySelectorAll("vaadin-board-row");
-        var row_default = rows[0].querySelector("div");
-        var row_smaller = rows[1].querySelector("div");
-        var row_larger = rows[2].querySelector("div");
+        var container;
+        var board;
+        var row_default;
+        var row_smaller;
+        var row_larger;
+        
+        beforeEach(function() {
+          container = fixture('board');
+          board = container.querySelectorAll("vaadin-board");
+          var rows = container.querySelectorAll("vaadin-board-row");
+          row_default = rows[0].querySelector("div");
+          row_smaller = rows[1].querySelector("div");
+          row_larger = rows[2].querySelector("div");
+        });
 
         function testSize(defaultColor, smallerColor, largerColor){
           assert.equal(defaultColor, window.getComputedStyle(row_default).backgroundColor);

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -15,34 +15,36 @@
   </head>
   <body>
     <test-fixture id="board">
-      <style>
-        vaadin-board-row {
-          --vaadin-board-width-small: 500px;
-          --vaadin-board-width-medium: 900px;
-        }
+      <custom-style>
+        <style>
+          vaadin-board-row {
+            --vaadin-board-width-small: 500px;
+            --vaadin-board-width-medium: 900px;
+          }
 
-        vaadin-board-row#smaller {
-          --vaadin-board-width-small: 300px;
-          --vaadin-board-width-medium: 700px;
-        }
+          vaadin-board-row#smaller {
+            --vaadin-board-width-small: 300px;
+            --vaadin-board-width-medium: 700px;
+          }
 
-        vaadin-board-row#larger {
-          --vaadin-board-width-small: 800px;
-          --vaadin-board-width-medium: 1300px;
-        }
+          vaadin-board-row#larger {
+            --vaadin-board-width-small: 800px;
+            --vaadin-board-width-medium: 1300px;
+          }
 
-        vaadin-board-row.large > div {
-          background-color: rgb(255, 0, 0);
-        }
+          vaadin-board-row.large > div {
+            background-color: rgb(255, 0, 0);
+          }
 
-        vaadin-board-row.medium > div {
-          background-color: rgb(0, 255, 0);
-        }
+          vaadin-board-row.medium > div {
+            background-color: rgb(0, 255, 0);
+          }
 
-        vaadin-board-row.small > div {
-          background-color: rgb(0, 0, 255);
-        }
-      </style>
+          vaadin-board-row.small > div {
+            background-color: rgb(0, 0, 255);
+          }
+        </style>
+      </custom-style>
       <template>
         <div id="board">
           <vaadin-board>

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>vaadin-board test</title>
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../vaadin-board.html">
+    <link rel="import" href="../vaadin-board-row.html">
+  </head>
+  <body>
+    <test-fixture id="board">
+      <style>
+
+        vaadin-board-row.large > div {
+          background-color: rgb(255, 0, 0);
+        }
+
+        vaadin-board-row.medium > div {
+          background-color: rgb(0, 255, 0);
+        }
+
+        vaadin-board-row.small > div {
+          background-color: rgb(0, 0, 255);
+        }
+      </style>
+      <template>
+        <div id="board">
+          <vaadin-board>
+            <vaadin-board-row id="default">
+              <div>top A</div>
+              <div>top B</div>
+            </vaadin-board-row>
+            <vaadin-board-row id="smaller" small-size="300" medium-size="700">
+              <div>top A</div>
+              <div>top B</div>
+              <div>top C</div>
+              <div>top D</div>
+            </vaadin-board-row>
+            <vaadin-board-row id="larger" small-size="800" medium-size="1300">
+              <div>top A</div>
+              <div>top B</div>
+              <div>top C</div>
+              <div>top D</div>
+            </vaadin-board-row>
+          </vaadin-board>
+        </div>
+      </template>
+    </test-fixture>
+    <script>
+      suite('vaadin-board', function () {
+        var container = fixture('board');
+        var board = container.querySelectorAll("vaadin-board");
+        var rows = container.querySelectorAll("vaadin-board-row");
+        var row_default = rows[0].querySelector("div");
+        var row_smaller = rows[1].querySelector("div");
+        var row_larger = rows[2].querySelector("div");
+
+        function testSize(defaultColor, smallerColor, largerColor){
+          assert.equal(defaultColor, window.getComputedStyle(row_default).backgroundColor);
+          assert.equal(smallerColor, window.getComputedStyle(row_smaller).backgroundColor);
+          assert.equal(largerColor, window.getComputedStyle(row_larger).backgroundColor);
+        }
+
+        test('Items inside the board-row has different styling, based on row size.', function () {
+          var large = "rgb(255, 0, 0)";
+          var medium = "rgb(0, 255, 0)";
+          var small = "rgb(0, 0, 255)";
+          
+          //Default 960 large test
+          container.setAttribute("style","width:980px");
+          board[0].redraw();
+          testSize(large, large, medium);
+          
+          container.setAttribute("style","width:940px");
+          board[0].redraw();
+          testSize(medium, large, medium);
+
+          //Default 600 medium test
+          container.setAttribute("style","width:620px");
+          board[0].redraw();
+          testSize(medium, medium, small);
+
+          container.setAttribute("style","width:580px");
+          board[0].redraw();
+          testSize(small, medium, small);
+
+          // 700 large test
+          container.setAttribute("style","width:720px");
+          board[0].redraw();
+          testSize(medium, large, small);
+
+          container.setAttribute("style","width:680px");
+          board[0].redraw();
+          testSize(medium, medium, small);
+          
+          // 300 medium test
+          container.setAttribute("style","width:320px");
+          board[0].redraw();
+          testSize(small, medium, small);
+
+          container.setAttribute("style","width:280px");
+          board[0].redraw();
+          testSize(small, small, small);
+
+          // 1300 large test
+          container.setAttribute("style","width:1320px");
+          board[0].redraw();
+          testSize(large, large, large);
+
+          container.setAttribute("style","width:1280px");
+          board[0].redraw();
+          testSize(large, large, medium);
+
+          // 800 medium test
+          container.setAttribute("style","width:820px");
+          board[0].redraw();
+          testSize(medium, large, medium);
+
+          container.setAttribute("style","width:780px");
+          board[0].redraw();
+          testSize(medium, large, small);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/vaadin-board_size_test.html
+++ b/test/vaadin-board_size_test.html
@@ -72,40 +72,39 @@
     </test-fixture>
     <script>
       suite('vaadin-board', function () {
-        var container;
-        var board;
         var row_default;
         var row_smaller;
         var row_larger;
 
-        function testSize(defaultColor, smallerColor, largerColor){
+        function testSize(defaultColor, smallerColor, largerColor) {
           assert.equal(defaultColor, window.getComputedStyle(row_default).backgroundColor);
           assert.equal(smallerColor, window.getComputedStyle(row_smaller).backgroundColor);
           assert.equal(largerColor, window.getComputedStyle(row_larger).backgroundColor);
         }
 
         test('Items inside the board-row has different styling, based on row size.', function () {
-          container = fixture('board');
-          board = container.querySelectorAll("vaadin-board");
-          var rows = container.querySelectorAll("vaadin-board-row");
+          const large = "rgb(255, 0, 0)";
+          const medium = "rgb(0, 255, 0)";
+          const small = "rgb(0, 0, 255)";
+
+          const container = fixture('board');
+          const board = container.querySelectorAll("vaadin-board");
+          const rows = container.querySelectorAll("vaadin-board-row");
+
           row_default = rows[0].querySelector("div");
           row_smaller = rows[1].querySelector("div");
           row_larger = rows[2].querySelector("div");
 
-          var large = "rgb(255, 0, 0)";
-          var medium = "rgb(0, 255, 0)";
-          var small = "rgb(0, 0, 255)";
-          
-          //Default 900 large test
+          // Default 900 large test
           container.setAttribute("style","width:920px");
           board[0].redraw();
           testSize(large, large, medium);
-          
+
           container.setAttribute("style","width:880px");
           board[0].redraw();
           testSize(medium, large, medium);
 
-          //Default 500 medium test
+          // Default 500 medium test
           container.setAttribute("style","width:520px");
           board[0].redraw();
           testSize(medium, medium, small);
@@ -122,7 +121,7 @@
           container.setAttribute("style","width:680px");
           board[0].redraw();
           testSize(medium, medium, small);
-          
+
           // 300 medium test
           container.setAttribute("style","width:320px");
           board[0].redraw();

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -224,8 +224,8 @@
             var mediumSize;
             this.updateStyles();
             if (window.ShadyCSS) {
-              smallSize = ShadyCSS.getComputedStyleValue(this, '--small-size');
-              mediumSize = ShadyCSS.getComputedStyleValue(this, '--medium-size');
+              smallSize = window.ShadyCSS.getComputedStyleValue(this, '--small-size');
+              mediumSize = window.ShadyCSS.getComputedStyleValue(this, '--medium-size');
             } else {
               smallSize = getComputedStyle(this).getPropertyValue('--small-size');
               mediumSize = getComputedStyle(this).getPropertyValue('--medium-size');

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -10,6 +10,8 @@
         flex-direction: row;
         flex-wrap: wrap;
         align-items: stretch;
+        --small-size: var(--vaadin-board-width-small, 600px);
+        --medium-size: var(--vaadin-board-width-medium, 960px);
       }
 
        :host ::slotted(*) {
@@ -40,14 +42,6 @@
 
         static get properties() {
           return {
-            smallSize: {
-              type: Number,
-              value: 600
-            },
-            mediumSize: {
-              type: Number,
-              value: 960
-            }
           }
         }
         constructor() {
@@ -84,12 +78,12 @@
         /**
          * Adds styles for board row based on width
          */
-        _addStyleNames(width) {
-          if (width < this.smallSize) {
+        _addStyleNames(width, breakpoints) {
+          if (width < breakpoints.smallSize) {
             this.classList.add(this._SMALL_VIEWPORT_CLASSNAME);
             this.classList.remove(this._MEDIUM_VIEWPORT_CLASSNAME);
             this.classList.remove(this._LARGE_VIEWPORT_CLASSNAME);
-          } else if (width < this.mediumSize) {
+          } else if (width < breakpoints.mediumSize) {
             this.classList.remove(this._SMALL_VIEWPORT_CLASSNAME);
             this.classList.add(this._MEDIUM_VIEWPORT_CLASSNAME);
             this.classList.remove(this._LARGE_VIEWPORT_CLASSNAME);
@@ -105,10 +99,10 @@
          * @param{Number} width of the row in px
          * @param{Number} amount of columns in the row
          */
-        _calculateFlexBasis(colSpan, width, colsInRow) {
-          if (width < this.smallSize) {
+        _calculateFlexBasis(colSpan, width, colsInRow, breakpoints) {
+          if (width < breakpoints.smallSize) {
             colsInRow = 1;
-          } else if (width < this.mediumSize && colsInRow == 4) {
+          } else if (width < breakpoints.mediumSize && colsInRow == 4) {
             colsInRow = 2;
           }
           let flexBasis = colSpan / colsInRow * 100;
@@ -200,11 +194,12 @@
                 || (node instanceof Polymer.DomIf));
             }
             const filteredNodes = nodes.filter(isElementNode);
-            this._addStyleNames(width);
+            const breakpoints = this._measureBreakpointsInPx();
+            this._addStyleNames(width, breakpoints);
             const boardCols = this._parseBoardCols(filteredNodes);
             const colsInRow = boardCols.reduce((a, b) => a + b, 0);
             this._removeExtraNodesFromDOM(boardCols, filteredNodes).forEach((e, i) => {
-              let newFlexBasis = this._calculateFlexBasis(boardCols[i], width, colsInRow);
+              let newFlexBasis = this._calculateFlexBasis(boardCols[i], width, colsInRow, breakpoints);
               if (forceResize || !this._oldFlexBasis[i] || this._oldFlexBasis[i] != newFlexBasis) {
                 this._oldFlexBasis[i] = newFlexBasis
                 e.style.flexBasis = newFlexBasis;
@@ -212,6 +207,25 @@
             });
             this._oldWidth = width;
           }
+        }
+
+        /**
+         * The breakpoints for small and medium can be given in any unit, px, em, in etc.
+         * We need to know them in px so that they are comparable with the actual size
+         *
+         * @return{Object} object with smallSize and mediumSize number properties, which tells
+         * where the row should switch rendering size in pixels.
+         */
+        _measureBreakpointsInPx() {
+            // Convert minWidth to px units for comparison
+            const breakpoints = {};
+            const tmpStyleProp = 'background-position';
+            this.style.setProperty(tmpStyleProp, this.getComputedStyleValue('--small-size'));
+            breakpoints.smallSize = parseFloat(getComputedStyle(this).getPropertyValue(tmpStyleProp));
+            this.style.setProperty(tmpStyleProp, this.getComputedStyleValue('--medium-size'));
+            breakpoints.mediumSize = parseFloat(getComputedStyle(this).getPropertyValue(tmpStyleProp));
+            this.style.removeProperty(tmpStyleProp);
+            return breakpoints;
         }
       }
       customElements.define(BoardRowElement.is, BoardRowElement);

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -40,10 +40,6 @@
           return "vaadin-board-row";
         }
 
-        static get properties() {
-          return {
-          }
-        }
         constructor() {
           super();
           this._onIronResize = this._onIronResize.bind(this);
@@ -222,7 +218,6 @@
             const tmpStyleProp = 'background-position';
             var smallSize;
             var mediumSize;
-            this.updateStyles();
             if (window.ShadyCSS) {
               smallSize = window.ShadyCSS.getComputedStyleValue(this, '--small-size');
               mediumSize = window.ShadyCSS.getComputedStyleValue(this, '--medium-size');

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -37,11 +37,22 @@
         static get is() {
           return "vaadin-board-row";
         }
+
+        static get properties() {
+          return {
+            smallSize: {
+              type: Number,
+              value: 600
+            },
+            mediumSize: {
+              type: Number,
+              value: 960
+            }
+          }
+        }
         constructor() {
           super();
           this._onIronResize = this._onIronResize.bind(this);
-          this._ONE_COLUMN_MAX_WIDTH = 600;
-          this._TWO_COLUMNS_MAX_WIDTH = 960;
 
           this._SMALL_VIEWPORT_CLASSNAME = "small";
           this._MEDIUM_VIEWPORT_CLASSNAME = "medium";
@@ -74,11 +85,11 @@
          * Adds styles for board row based on width
          */
         _addStyleNames(width) {
-          if (width < this._ONE_COLUMN_MAX_WIDTH) {
+          if (width < this.smallSize) {
             this.classList.add(this._SMALL_VIEWPORT_CLASSNAME);
             this.classList.remove(this._MEDIUM_VIEWPORT_CLASSNAME);
             this.classList.remove(this._LARGE_VIEWPORT_CLASSNAME);
-          } else if (width < this._TWO_COLUMNS_MAX_WIDTH) {
+          } else if (width < this.mediumSize) {
             this.classList.remove(this._SMALL_VIEWPORT_CLASSNAME);
             this.classList.add(this._MEDIUM_VIEWPORT_CLASSNAME);
             this.classList.remove(this._LARGE_VIEWPORT_CLASSNAME);
@@ -95,9 +106,9 @@
          * @param{Number} amount of columns in the row
          */
         _calculateFlexBasis(colSpan, width, colsInRow) {
-          if (width < this._ONE_COLUMN_MAX_WIDTH) {
+          if (width < this.smallSize) {
             colsInRow = 1;
-          } else if (width < this._TWO_COLUMNS_MAX_WIDTH && colsInRow == 4) {
+          } else if (width < this.mediumSize && colsInRow == 4) {
             colsInRow = 2;
           }
           let flexBasis = colSpan / colsInRow * 100;

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -38,7 +38,7 @@
           return "vaadin-board-row";
         }
 
-        static get properties() {
+        static get properties() {
           return {
             smallSize: {
               type: Number,

--- a/vaadin-board-row.html
+++ b/vaadin-board-row.html
@@ -220,9 +220,19 @@
             // Convert minWidth to px units for comparison
             const breakpoints = {};
             const tmpStyleProp = 'background-position';
-            this.style.setProperty(tmpStyleProp, this.getComputedStyleValue('--small-size'));
+            var smallSize;
+            var mediumSize;
+            this.updateStyles();
+            if (window.ShadyCSS) {
+              smallSize = ShadyCSS.getComputedStyleValue(this, '--small-size');
+              mediumSize = ShadyCSS.getComputedStyleValue(this, '--medium-size');
+            } else {
+              smallSize = getComputedStyle(this).getPropertyValue('--small-size');
+              mediumSize = getComputedStyle(this).getPropertyValue('--medium-size');
+            }
+            this.style.setProperty(tmpStyleProp, smallSize);
             breakpoints.smallSize = parseFloat(getComputedStyle(this).getPropertyValue(tmpStyleProp));
-            this.style.setProperty(tmpStyleProp, this.getComputedStyleValue('--medium-size'));
+            this.style.setProperty(tmpStyleProp, mediumSize);
             breakpoints.mediumSize = parseFloat(getComputedStyle(this).getPropertyValue(tmpStyleProp));
             this.style.removeProperty(tmpStyleProp);
             return breakpoints;


### PR DESCRIPTION
Up until now, board-rows were always in large mode when over 960px, in medium when between 600px and 960px and small when under 600px. Now these are the defaults but they are configurable with properties small-size and medium-size. Example
```
<vaadin-board>
  <vaadin-board-row small-size="300" medium-size="500">
    ...
  </vaadin-board-row>
</vaadin-board>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/85)
<!-- Reviewable:end -->
