### PR TITLE
Add 'main' to package.json for easy imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,20 @@
 {
   "name": "vaadin-board",
   "version": "2.0.0",
-  "description": "Polymer element to create flexible responsive layouts and build nice looking dashboard.",
+  "description": "Web component to create flexible responsive layouts and build nice looking dashboard.",
+  "main": "vaadin-button.html",
+  "repository": "vaadin/vaadin-board",
+  "keywords": [
+    "Vaadin",
+    "Board",
+    "responsive",
+    "layout",
+    "web-components",
+    "web-component",
+    "polymer"
+  ],
   "author": "Vaadin Ltd",
   "license": "https://raw.githubusercontent.com/vaadin/vaadin-board/master/LICENSE.txt",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/vaadin/vaadin-board.git"
-  },
   "bugs": {
     "url": "https://github.com/vaadin/vaadin-board/issues"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vaadin-board",
   "version": "2.0.0",
   "description": "Web component to create flexible responsive layouts and build nice looking dashboard.",
-  "main": "vaadin-button.html",
+  "main": "vaadin-board.js",
   "repository": "vaadin/vaadin-board",
   "keywords": [
     "Vaadin",


### PR DESCRIPTION
Added `"main": "vaadin-button.html"`, to package.json. The reason is that this enables easy imports in NPM of the modules.

Without this main definition you have to import like this:
`import '@vaadin/vaadin-board/vaadin-board.js'`

With the main definition, you can shorten it:
import '@vaadin/vaadin-board'

At the same time I harmonized the board package json to be in the same format as other Vaadin components. I took example from vaadin/vaadin-button/package.json

- Description says "web component" instead of "Polymer"
- Repostory string in same format
- Relevant keywords

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/104)
<!-- Reviewable:end -->
