### PR TITLE
refactor: only run license checker when needed

### DIFF
--- a/src/vaadin-board.html
+++ b/src/vaadin-board.html
@@ -53,6 +53,19 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           return '2.1.0';
         }
 
+        /**
+         * @protected
+         */
+        static _finalizeClass() {
+          super._finalizeClass();
+
+          const devModeCallback = window.Vaadin.developmentModeCallback;
+          const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
+          if (typeof licenseChecker === 'function') {
+            licenseChecker(BoardElement);
+          }
+        }
+
         constructor() {
           super();
         }
@@ -79,12 +92,6 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
        * @namespace Vaadin
        */
       window.Vaadin.BoardElement = BoardElement;
-
-      const licenseChecker = window.Vaadin.developmentModeCallback
-        && window.Vaadin.developmentModeCallback['vaadin-license-checker'];
-      if (typeof licenseChecker === 'function') {
-        licenseChecker(BoardElement);
-      }
     })();
   </script>
 </dom-module>

--- a/src/vaadin-board.html
+++ b/src/vaadin-board.html
@@ -66,21 +66,13 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
           }
         }
 
-        constructor() {
-          super();
-        }
-
-        connectedCallback() {
-          super.connectedCallback();
-        }
-
         /**
          * Redraws the board and all rows inside it, if necessary.
          *
          * In most cases, board will redraw itself if your reconfigure it. If you dynamically change CSS
          * which affects this element, then you need to call this method.
-         **/
-         redraw() {
+         */
+        redraw() {
           this.notifyResize();
         }
 


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#492

This PR makes sure the license checker is only called when the component is created.
The static `_finalizeClass` method is needed to ensure we call it [once per class](https://github.com/Polymer/polymer/blob/f6ccc9d1bdc81e934e21bf27b3dba517b5840fd4/lib/mixins/properties-mixin.js#L138-L147).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board/125)
<!-- Reviewable:end -->
