### PR TITLE
fix: do not recalculate flex basis for hidden rows

### DIFF
--- a/src/vaadin-board-row.html
+++ b/src/vaadin-board-row.html
@@ -254,7 +254,7 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
         /** @private */
         _shouldRecalculate(width, breakpoints) {
           // Should not recalculate if row is invisible
-          if (_isElementHidden()) {
+          if (this._isElementHidden()) {
             return false;
           }
           return (

--- a/src/vaadin-board-row.html
+++ b/src/vaadin-board-row.html
@@ -228,9 +228,13 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
         _recalculateFlexBasis(forceResize) {
           const width = this.getBoundingClientRect().width;
           const breakpoints = this._measureBreakpointsInPx();
-          if (forceResize || width != this._oldWidth
-              || breakpoints.smallSize != this._oldBreakpoints.smallSize
-              || breakpoints.mediumSize != this._oldBreakpoints.mediumSize) {
+          const shouldRecalculate =
+            forceResize ||
+            (this.offsetParent !== null &&
+              (width != this._oldWidth ||
+                breakpoints.smallSize != this._oldBreakpoints.smallSize ||
+                breakpoints.mediumSize != this._oldBreakpoints.mediumSize));
+          if (shouldRecalculate) {
             const nodes = this.$.insertionPoint.assignedNodes({ flatten: true });
             const isElementNode = function (node) {
               return !((node.nodeType === node.TEXT_NODE)

--- a/src/vaadin-board-row.html
+++ b/src/vaadin-board-row.html
@@ -254,7 +254,7 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
         /** @private */
         _shouldRecalculate(width, breakpoints) {
           // Should not recalculate if row is invisible
-          if (this.offsetParent === null) {
+          if (_isElementHidden()) {
             return false;
           }
           return (
@@ -262,6 +262,24 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
             breakpoints.smallSize !== this._oldBreakpoints.smallSize ||
             breakpoints.mediumSize !== this._oldBreakpoints.mediumSize
           );
+        }
+
+        /** @private */
+        _isElementHidden() {
+          // `offsetParent` is `null` when the element itself
+          // or one of its ancestors is hidden with `display: none`.
+          // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+          // However `offsetParent` is also null when the element is using fixed
+          // positioning, so additionally check if the element takes up layout space.
+          if (this.offsetParent === null && this.clientWidth === 0 && this.clientHeight === 0) {
+            return true;
+          }
+          // Check inline style first to save a re-flow.
+          if (this.style.visibility === 'hidden' || this.style.display === 'none') {
+            return true;
+          }
+          const computedStyle = window.getComputedStyle(this);
+          return computedStyle.visibility === 'hidden' || computedStyle.display === 'none';
         }
 
         /**

--- a/src/vaadin-board-row.html
+++ b/src/vaadin-board-row.html
@@ -228,13 +228,7 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
         _recalculateFlexBasis(forceResize) {
           const width = this.getBoundingClientRect().width;
           const breakpoints = this._measureBreakpointsInPx();
-          const shouldRecalculate =
-            forceResize ||
-            (this.offsetParent !== null &&
-              (width != this._oldWidth ||
-                breakpoints.smallSize != this._oldBreakpoints.smallSize ||
-                breakpoints.mediumSize != this._oldBreakpoints.mediumSize));
-          if (shouldRecalculate) {
+          if (forceResize || this._shouldRecalculate(width, breakpoints)) {
             const nodes = this.$.insertionPoint.assignedNodes({ flatten: true });
             const isElementNode = function (node) {
               return !((node.nodeType === node.TEXT_NODE)
@@ -255,6 +249,19 @@ This program is available under Commercial Vaadin Add-On License 3.0, available 
             this._oldWidth = width;
             this._oldBreakpoints = breakpoints;
           }
+        }
+
+        /** @private */
+        _shouldRecalculate(width, breakpoints) {
+          // Should not recalculate if row is invisible
+          if (this.offsetParent === null) {
+            return false;
+          }
+          return (
+            width !== this._oldWidth ||
+            breakpoints.smallSize !== this._oldBreakpoints.smallSize ||
+            breakpoints.mediumSize !== this._oldBreakpoints.mediumSize
+          );
         }
 
         /**

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -124,6 +124,33 @@
             assert.approximately(rect.top, (Math.floor(i / 2) * rowRect.height / 2) + rowRect.top, 1);
           }
         });
+
+        test("Resize event should not trigger recalculating flex basis for a hidden row ", function () {
+          const row = fixture("board-row-4-items");
+
+          row.style.width = "700px";
+          row.redraw();
+
+          const initialFlexBasis = row.style.flexBasis;
+
+          row.toggleAttribute("hidden");
+          row.style.width = "100px";
+
+          assert.equal(initialFlexBasis, row.style.flexBasis);
+        });
+
+        test("Resize event should trigger recalculating flex basis for a visible row ", function () {
+          const row = fixture("board-row-4-items");
+
+          row.style.width = "700px";
+          row.redraw();
+
+          const initialFlexBasis = row.style.flexBasis;
+
+          row.style.width = "100px";
+
+          assert.notEqual(initialFlexBasis, row.style.flexBasis);
+        });
       });
     </script>
   </body>

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -125,7 +125,7 @@
           }
         });
 
-        test("Resize event should not trigger recalculating flex basis for a hidden row ", function () {
+        test("Resize event should not trigger recalculating flex basis for a hidden row", function () {
           const board = fixture('board-1-row-4-items');
           const row = board.querySelector('#top');
 
@@ -137,13 +137,26 @@
           assert.equal(initialClassName, row.className);
         });
 
-        test("Resize event should trigger recalculating flex basis for a visible row ", function () {
+        test("Resize event should trigger recalculating flex basis for a visible row", function () {
           const board = fixture('board-1-row-4-items');
           const row = board.querySelector('#top');
 
           const initialClassName = row.className;
 
           board.style.width = "100px";
+
+          assert.notEqual(initialClassName, row.className);
+        });
+
+        test("Setting a resized hidden row visible should trigger recalculating flex basis", function () {
+          const board = fixture('board-1-row-4-items');
+          const row = board.querySelector('#top');
+
+          const initialClassName = row.className;
+
+          row.toggleAttribute("hidden");
+          board.style.width = "100px";
+          row.toggleAttribute("hidden");
 
           assert.notEqual(initialClassName, row.className);
         });

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -131,12 +131,12 @@
           row.style.width = "700px";
           row.redraw();
 
-          const initialFlexBasis = row.style.flexBasis;
+          const initialClassName = row.className;
 
           row.toggleAttribute("hidden");
           row.style.width = "100px";
 
-          assert.equal(initialFlexBasis, row.style.flexBasis);
+          assert.equal(initialClassName, row.className);
         });
 
         test("Resize event should trigger recalculating flex basis for a visible row ", function () {
@@ -145,11 +145,11 @@
           row.style.width = "700px";
           row.redraw();
 
-          const initialFlexBasis = row.style.flexBasis;
+          const initialClassName = row.className;
 
           row.style.width = "100px";
 
-          assert.notEqual(initialFlexBasis, row.style.flexBasis);
+          assert.notEqual(initialClassName, row.className);
         });
       });
     </script>

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -126,28 +126,26 @@
         });
 
         test("Resize event should not trigger recalculating flex basis for a hidden row ", function () {
-          const row = fixture("board-row-4-items");
-
-          row.style.width = "700px";
-          row.redraw();
+          const board = fixture('board-1-row-4-items');
+          const row = board.querySelector('#top');
 
           const initialClassName = row.className;
 
           row.toggleAttribute("hidden");
-          row.style.width = "100px";
+          board.style.width = "100px";
+          board.redraw();
 
           assert.equal(initialClassName, row.className);
         });
 
         test("Resize event should trigger recalculating flex basis for a visible row ", function () {
-          const row = fixture("board-row-4-items");
-
-          row.style.width = "700px";
-          row.redraw();
+          const board = fixture('board-1-row-4-items');
+          const row = board.querySelector('#top');
 
           const initialClassName = row.className;
 
-          row.style.width = "100px";
+          board.style.width = "100px";
+          board.redraw();
 
           assert.notEqual(initialClassName, row.className);
         });

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -133,6 +133,7 @@
 
           row.toggleAttribute("hidden");
           board.style.width = "100px";
+          row.fire('iron-resize');
 
           assert.equal(initialClassName, row.className);
         });
@@ -144,19 +145,7 @@
           const initialClassName = row.className;
 
           board.style.width = "100px";
-
-          assert.notEqual(initialClassName, row.className);
-        });
-
-        test("Setting a resized hidden row visible should trigger recalculating flex basis", function () {
-          const board = fixture('board-1-row-4-items');
-          const row = board.querySelector('#top');
-
-          const initialClassName = row.className;
-
-          row.toggleAttribute("hidden");
-          board.style.width = "100px";
-          row.toggleAttribute("hidden");
+          row.fire('iron-resize');
 
           assert.notEqual(initialClassName, row.className);
         });

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -131,7 +131,7 @@
 
           const initialClassName = row.className;
 
-          row.toggleAttribute("hidden");
+          row.style.display = 'none';
           row.style.width = "100px";
           row.fire('resize');
 

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -132,8 +132,8 @@
           const initialClassName = row.className;
 
           row.toggleAttribute("hidden");
-          board.style.width = "100px";
-          row.fire('iron-resize');
+          row.style.width = "100px";
+          row.fire('resize');
 
           assert.equal(initialClassName, row.className);
         });
@@ -144,8 +144,8 @@
 
           const initialClassName = row.className;
 
-          board.style.width = "100px";
-          row.fire('iron-resize');
+          row.style.width = "100px";
+          row.fire('resize');
 
           assert.notEqual(initialClassName, row.className);
         });

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -125,27 +125,40 @@
           }
         });
 
-        test("Resize event should not trigger recalculating flex basis for a hidden row", function () {
-          const board = fixture('board-1-row-4-items');
-          const row = board.querySelector('#top');
+        test("Resize event should not trigger recalculating flex basis for a directly hidden row", function () {
+          const board = fixture("board-1-row-4-items");
+          const row = board.querySelector("#top");
 
           const initialClassName = row.className;
 
-          row.style.display = 'none';
+          row.style.display = "none";
           row.style.width = "100px";
-          row.fire('resize');
+          row.fire("resize");
+
+          assert.equal(initialClassName, row.className);
+        });
+
+        test("Resize event should not trigger recalculating flex basis for a row hidden through an ancestor", function () {
+          const board = fixture("board-1-row-4-items");
+          const row = board.querySelector("#top");
+
+          const initialClassName = row.className;
+
+          board.style.display = "none";
+          row.style.width = "100px";
+          row.fire("resize");
 
           assert.equal(initialClassName, row.className);
         });
 
         test("Resize event should trigger recalculating flex basis for a visible row", function () {
-          const board = fixture('board-1-row-4-items');
-          const row = board.querySelector('#top');
+          const board = fixture("board-1-row-4-items");
+          const row = board.querySelector("#top");
 
           const initialClassName = row.className;
 
           row.style.width = "100px";
-          row.fire('resize');
+          row.fire("resize");
 
           assert.notEqual(initialClassName, row.className);
         });

--- a/test/vaadin-board_redraw_test.html
+++ b/test/vaadin-board_redraw_test.html
@@ -133,7 +133,6 @@
 
           row.toggleAttribute("hidden");
           board.style.width = "100px";
-          board.redraw();
 
           assert.equal(initialClassName, row.className);
         });
@@ -145,7 +144,6 @@
           const initialClassName = row.className;
 
           board.style.width = "100px";
-          board.redraw();
 
           assert.notEqual(initialClassName, row.className);
         });


### PR DESCRIPTION
## Description

Currently, when a board is set invisible, flex basis is still recalculated on resize. This causes flickering when toggling visibility. This PR makes the row recalculate flex basis only when it is visible. Note that if any resizing occurs while the element is hidden, it should be explicitly updated with a `redraw()` call similar to the grid columns.

Fixes https://github.com/vaadin/flow-components/issues/5005
See: [Monorepo PR](https://github.com/vaadin/web-components/pull/5840)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.